### PR TITLE
next/font

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "browserslist": "defaults, not ie <= 11",
   "dependencies": {
+    "@next/font": "^13.0.5",
     "@tailwindcss/typography": "^0.5.8",
     "@vercel/analytics": "^0.1.5",
     "autoprefixer": "^10.4.13",

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -3,6 +3,12 @@ import { Analytics } from '@vercel/analytics/react'
 import { Footer } from '../components/Footer'
 import { Header } from '../components/Header'
 
+import { Inter } from '@next/font/google'
+const inter = Inter({
+  subsets: ['latin'],
+  variable: '--font-inter',
+})
+
 import '../styles/tailwind.css'
 
 export default function App({ Component, pageProps }) {
@@ -15,7 +21,7 @@ export default function App({ Component, pageProps }) {
       </div>
       <div className="relative">
         <Header />
-        <main>
+        <main className={`${inter.variable} font-sans`}>
           <Component {...pageProps} />
         </main>
         <Footer />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,3 +1,5 @@
+const { fontFamily } = require('tailwindcss/defaultTheme')
+
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
@@ -303,5 +305,10 @@ module.exports = {
         },
       },
     }),
+    extend: {
+      fontFamily: {
+        sans: ['var(--font-inter)', ...fontFamily.sans],
+      },
+    },
   },
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -63,6 +63,11 @@
   dependencies:
     glob "7.1.7"
 
+"@next/font@^13.0.5":
+  version "13.0.5"
+  resolved "https://registry.yarnpkg.com/@next/font/-/font-13.0.5.tgz#db0ef389d926d3a8b649db8aa76e67f9502a478f"
+  integrity sha512-NrP4B8pxwerrkkuG/m7MQv0ks89Kk4Lc0kzbiRaYX+Xb0coDaw+I9T+g42aOHf8j8ta1vtKqb5XE1+troZ4CoQ==
+
 "@next/swc-android-arm-eabi@13.0.5":
   version "13.0.5"
   resolved "https://registry.yarnpkg.com/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.0.5.tgz#bb83f8a8bea5d3d813059a28624e9ff3c0c22bac"


### PR DESCRIPTION
- added Google font using `next/font`
- https://nextjs.org/docs/api-reference/next/font


## Network tab before and after:

![CleanShot 2022-11-27 at 02 11 08](https://user-images.githubusercontent.com/1570963/204116162-4ae3b7a4-70eb-452f-8b7a-4eaf918e724e.png)

## Lighthouse score and Core Web Vitals

![CleanShot 2022-11-27 at 02 14 44](https://user-images.githubusercontent.com/1570963/204116255-4267c3f5-5084-4eba-bdf5-6f0303c7af13.png)

